### PR TITLE
Reconciliation enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "akaunting",
             "version": "2.0.0",
             "dependencies": {
                 "@babel/plugin-syntax-dynamic-import": "^7.2.0",

--- a/resources/assets/js/views/banking/reconciliations.js
+++ b/resources/assets/js/views/banking/reconciliations.js
@@ -7,24 +7,24 @@
  require('./../../bootstrap');
 
  import Vue from 'vue';
- 
+
  import DashboardPlugin from './../../plugins/dashboard-plugin';
- 
+
  import Global from './../../mixins/global';
- 
+
  import Form from './../../plugins/form';
  import BulkAction from './../../plugins/bulk-action';
- 
+
  // plugin setup
  Vue.use(DashboardPlugin);
- 
+
  const app = new Vue({
      el: '#app',
- 
+
      mixins: [
          Global
      ],
- 
+
      data: function () {
          return {
              form: new Form('reconciliation'),
@@ -39,18 +39,18 @@
              min_due_date: false
          }
      },
- 
+
      mounted() {
          if (document.getElementById('closing_balance') != null) {
              this.totals.closing_balance = parseFloat(document.getElementById('closing_balance').value);
          }
- 
+
          if (this.form._method == 'PATCH') {
              this.onCalculate();
          }
          this.currencyConversion();
      },
- 
+
      methods:{
          setDueMinDate(date) {
              this.min_due_date = date;
@@ -66,57 +66,57 @@
                 }
               }, 250)
          },
-         
+
          onReconcilition() {
              let form = document.getElementById('form-create-reconciliation');
- 
+
              let path = form.action +'?started_at=' + this.form.started_at + '&ended_at=' + this.form.ended_at + '&closing_balance=' + this.form.closing_balance + '&account_id=' + this.form.account_id;
- 
+
              window.location.href = path;
          },
- 
+
          onCalculate() {
              this.reconcile = true;
              this.difference = null;
- 
+
              let transactions = this.form.transactions;
- 
+
              let cleared_amount = 0;
              let closing_balance = parseFloat(this.form.closing_balance);
              let difference = 0;
              let income_total = 0;
              let expense_total = 0;
- 
+
              this.totals.closing_balance = closing_balance;
- 
+
              if (transactions) {
                  // get all transactions.
                  Object.keys(transactions).forEach(function(transaction) {
-                     if (!transactions[transaction]) {
+                     if (transactions[transaction].length === 0) {
                          return;
                      }
- 
+
                      let type = transaction.split('_');
- 
+
                      if (type[0] == 'income') {
                          income_total += parseFloat(document.getElementById('transaction-' + type[1] + '-' + type[0]).value);
                      } else {
                          expense_total += parseFloat(document.getElementById('transaction-' + type[1] + '-' + type[0]).value);
                      }
                  });
- 
- 
+
+
                  let transaction_total = income_total - expense_total;
- 
+
                  cleared_amount = parseFloat(this.form.opening_balance) + transaction_total;
              }
- 
+
              if (cleared_amount > 0) {
                  difference = (parseFloat(this.form.closing_balance) - parseFloat(cleared_amount)).toFixed(this.currency.precision);
              } else {
                  difference = (parseFloat(this.form.closing_balance) + parseFloat(cleared_amount)).toFixed(this.currency.precision);
              }
- 
+
              if (difference != 0) {
                  this.difference = 'table-danger';
                  this.reconcile = true;
@@ -124,16 +124,15 @@
                  this.difference = 'table-success';
                  this.reconcile = false;
              }
- 
+
              this.totals.cleared_amount = parseFloat(cleared_amount);
              this.totals.difference = difference;
          },
- 
+
          onReconcileSubmit() {
              this.form.reconcile = 1;
- 
+
              this.form.submit();
          }
      },
  });
- 


### PR DESCRIPTION
Allow transactions to utilize the "Cleared" checkbox when reconciling an account.

Client side changes
Test if transactions[transaction].lentgh === 0 as this returns an empty array when the Cleared checkbox is not checked.

Server side changes 
Query all transactions created before reconciliation end_date and have not cleared (reconciled === 0)
Query all transactions created before reconciliation start_date that have cleared (reconcilied === 1) for opening balance
Sort reconciliations by end_date descending so most recent reconcilations are at top of list
(Optional) Revesed sort order on transaction list to oldest first instead of last.